### PR TITLE
fix: OKE, healthcheck and oci provider 

### DIFF
--- a/hub-apim/provider.tf
+++ b/hub-apim/provider.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     oci = {
       source  = "oracle/oci"
-      version = "6.35.0"
+      version = "7.0.0"
     }
     helm = {
       version = "3.0.0-pre2"

--- a/hub-apim/schema.yaml
+++ b/hub-apim/schema.yaml
@@ -133,7 +133,7 @@ variables:
     required: true
     multiline: true
     title: Traefik Helm Chart values
-    default: "ingressRoute:\n  dashboard:\n    enabled: true\n  healthcheck:\n    enabled: true\n    matchRule: PathPrefix(`/healthz`)\n    entryPoints: [\"web\", \"websecure\"]"
+    default: "ingressRoute:\n  dashboard:\n    enabled: true"
 
   chart_namespace:
     type: string

--- a/hub/provider.tf
+++ b/hub/provider.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     oci = {
       source  = "oracle/oci"
-      version = "6.35.0"
+      version = "7.0.0"
     }
     helm = {
       version = "3.0.0-pre2"

--- a/hub/schema.yaml
+++ b/hub/schema.yaml
@@ -135,7 +135,7 @@ variables:
     multiline: true
     title: Traefik Helm Chart values
     description: "See https://github.com/traefik/traefik-helm-chart/blob/master/EXAMPLES.md"
-    default: "ingressRoute:\n  dashboard:\n    enabled: true\n  healthcheck:\n    enabled: true\n    matchRule: PathPrefix(`/healthz`)\n    entryPoints: [\"web\", \"websecure\"]"
+    default: "ingressRoute:\n  dashboard:\n    enabled: true"
 
   chart_namespace:
     type: string

--- a/oke/main.tf
+++ b/oke/main.tf
@@ -16,7 +16,7 @@ data "oci_containerengine_node_pool_option" "current" {
 }
 
 locals {
-  kubernetes_version = reverse(data.oci_containerengine_cluster_option.current.kubernetes_versions)[0]
+  kubernetes_version = reverse(data.oci_containerengine_cluster_option.current.kubernetes_versions)[1]
 
   oke_sources = data.oci_containerengine_node_pool_option.current.sources
 

--- a/proxy/provider.tf
+++ b/proxy/provider.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     oci = {
       source  = "oracle/oci"
-      version = "6.35.0"
+      version = "7.0.0"
     }
     helm = {
       version = "3.0.0-pre2"

--- a/proxy/schema.yaml
+++ b/proxy/schema.yaml
@@ -119,7 +119,7 @@ variables:
     multiline: true
     title: Traefik Helm Chart values
     description: "See https://github.com/traefik/traefik-helm-chart/blob/master/EXAMPLES.md"
-    default: "ingressRoute:\n  dashboard:\n    enabled: true\n  healthcheck:\n    enabled: true\n    matchRule: PathPrefix(`/healthz`)\n    entryPoints: [\"web\", \"websecure\"]"
+    default: "ingressRoute:\n  dashboard:\n    enabled: true"
 
   chart_namespace:
     type: string


### PR DESCRIPTION
# What does it do ?

1. Take _latest - 1_ OKE version instead of _latest_
2. Remove unnecessary healthcheck
3. Update oci provider version to v7

# Motivation

Take into account latest feedbacks
