### PR TITLE
fix: always take the lastest kubernetes patch version

### DIFF
--- a/oke/variables.tf
+++ b/oke/variables.tf
@@ -25,3 +25,8 @@ variable "oke_nodes_mem_in_gb" {
   type    = string
   default = "8"
 }
+
+variable "oke_kubernetes_version" {
+  type    = string
+  default = "v1.33"
+}


### PR DESCRIPTION
# Motivation

This PR fixes the OKE spawn (especially node pool creation).

cf. https://github.com/traefik/infra/issues/9032
